### PR TITLE
Geo Gazetteer as a REST API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ edu.usc.ir.geo.gazetteer.GeoNameResolver -i geoIndex -b allCountries.txt`
 -cp target/lucene-geo-gazetteer-<version>-jar-with-dependencies.jar
 edu.usc.ir.geo.gazetteer.GeoNameResolver -i geoIndex -s Pasadena
 Texas`
-
+5. The service mode:
+  ```
+  #Launch Server
+  $ lucene-geo-gazetteer -server
+  # Query
+  $ curl "localhost:8765?q=Bangalore&q=Los+Angeles"
+  ```
 Questions, comments?  
 =================== 
 Send them to [Chris A. Mattmann](mailto:chris.a.mattmann@jpl.nasa.gov).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Texas`
   #Launch Server
   $ lucene-geo-gazetteer -server
   # Query
-  $ curl "localhost:8765?q=Bangalore&q=Los+Angeles"
+  $ curl "localhost:8765/api/search?s=Pasadena&s=Texas&c=2"
   ```
 Questions, comments?  
 =================== 

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,9 @@
 	<groupId>edu.usc.ir</groupId>
 	<artifactId>lucene-geo-gazetteer</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<properties>
+		<jetty.version>9.3.6.v20151106</jetty.version>
+	</properties>
 	<name>Geonames Gazetteer using Lucene</name>
 	<description>An implementation of a geonames.org-based Gazetteer using Apache Lucene.</description>
 	<build>
@@ -61,6 +64,11 @@
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>${jetty.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.usc.ir</groupId>
 	<artifactId>lucene-geo-gazetteer</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<properties>
-		<jetty.version>9.3.6.v20151106</jetty.version>
+		<tomcat.version>8.0.28</tomcat.version>
+		<cxf.version>2.2.3</cxf.version>
 	</properties>
 	<name>Geonames Gazetteer using Lucene</name>
 	<description>An implementation of a geonames.org-based Gazetteer using Apache Lucene.</description>
@@ -13,15 +14,15 @@
 		<sourceDirectory>${basedir}/src/main/java</sourceDirectory>
 		<testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
 		<plugins>
-	       <plugin>
-	            <groupId>org.apache.maven.plugins</groupId>
-	            <artifactId>maven-compiler-plugin</artifactId>
-	            <version>3.3</version>
-	            <configuration>
-	            <source>1.7</source>
-	            <target>1.7</target>
-	        </configuration>
-	       </plugin>		
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
@@ -65,10 +66,32 @@
 			<artifactId>commons-cli</artifactId>
 			<version>1.3</version>
 		</dependency>
+
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxrs</artifactId>
+			<version>${cxf.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+			<version>${cxf.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-logging-juli</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-jasper</artifactId>
+			<version>${tomcat.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
@@ -17,11 +17,16 @@
 
 package edu.usc.ir.geo.gazetteer;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -64,8 +69,13 @@ import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 
-public class GeoNameResolver {
+public class GeoNameResolver implements Closeable {
 	/**
 	 * Below constants define name of field in lucene index
 	 */
@@ -86,7 +96,7 @@ public class GeoNameResolver {
 	private static final int WEIGHT_SORT_ORDER = 20;
 	private static final int WEIGHT_SIZE_ALT_NAME = 50;
 	private static final int WEIGHT_NAME_MATCH = 15000;
-	
+
 	private static final Logger LOG = Logger.getLogger(GeoNameResolver.class
 			.getName());
 	private static final Double OUT_OF_BOUNDS = 999999.0;
@@ -95,24 +105,58 @@ public class GeoNameResolver {
 	private static Directory indexDir;
 	private static int hitsPerPage = 8;
 
+	private IndexReader indexReader;
+
+	public GeoNameResolver(){
+	}
+
+	/**
+	 * Creates a GeoNameResolver for given path
+	 * @param indexPath the path to lucene index
+	 * @throws IOException
+	 */
+	public GeoNameResolver(String indexPath) throws IOException {
+		this.indexReader = createIndexReader(indexPath);
+	}
+
+	/**
+	 *
+	 * @param locationNames List of location na,es
+	 * @param count Number of results per location
+	 * @return resolved Geo Names
+	 * @throws IOException
+	 */
+	public HashMap<String, List<String>> searchGeoName(List<String> locationNames,
+													   int count) throws IOException {
+		return resolveEntities(locationNames, count, this.indexReader);
+	}
+
 	/**
 	 * Search corresponding GeoName for each location entity
 	 * @param count
 	 * 			  Number of results for one locations
 	 * @param querystr
 	 *            it's the NER actually
-	 * 
+	 *
 	 * @return HashMap each name has a list of resolved entities
 	 * @throws IOException
 	 * @throws RuntimeException
 	 */
 
-	public HashMap<String, List<String>> searchGeoName(String indexerPath, 
-			List<String> locationNameEntities, int count) throws IOException {
+	public HashMap<String, List<String>> searchGeoName(String indexerPath,
+													   List<String> locationNameEntities, int count) throws IOException {
 
 		if (locationNameEntities.size() == 0
 				|| locationNameEntities.get(0).length() == 0)
 			return new HashMap<String, List<String>>();
+		IndexReader reader = createIndexReader(indexerPath);
+		HashMap<String, List<String>> resolvedEntities = resolveEntities(locationNameEntities, count, reader);
+		reader.close();
+		return resolvedEntities;
+
+	}
+
+	private IndexReader createIndexReader(String indexerPath) throws IOException {
 		File indexfile = new File(indexerPath);
 		indexDir = FSDirectory.open(indexfile.toPath());
 
@@ -123,34 +167,37 @@ public class GeoNameResolver {
 			System.exit(1);
 		}
 
-		IndexReader reader = DirectoryReader.open(indexDir);
+		return DirectoryReader.open(indexDir);
+	}
 
-		if (locationNameEntities.size() >= 200)
+	private HashMap<String, List<String>> resolveEntities(List<String> locationNames,
+														  int count, IndexReader reader) throws IOException {
+		if (locationNames.size() >= 200)
 			hitsPerPage = 5; // avoid heavy computation
 		IndexSearcher searcher = new IndexSearcher(reader);
 		Query q = null;
 
 		HashMap<String, List<List<String>>> allCandidates = new HashMap<String, List<List<String>>>();
 
-		for (String name : locationNameEntities) {
+		for (String name : locationNames) {
 
 			if (!allCandidates.containsKey(name)) {
 				try {
 					//query is wrapped in additional quotes (") to avoid query tokenization on space
 					q = new MultiFieldQueryParser(new String[] { FIELD_NAME_NAME,
 							FIELD_NAME_ALTERNATE_NAMES }, analyzer).parse(String.format("\"%s\"", name) );
-										
+
 					//"feature class" sort order as defined in FeatureClassComparator
 					SortField featureClassSort = CustomLuceneGeoGazetteerComparator.getFeatureClassSortField();
-					
+
 					//"feature code" sort order as defined in FeatureClassComparator
 					SortField featureCodeSort = CustomLuceneGeoGazetteerComparator.getFeatureCodeSortField();
-					
+
 					//sort descending on population
 					SortField populationSort = new SortedNumericSortField(FIELD_NAME_POPULATION, SortField.Type.LONG, true);
-					
+
 					Sort sort = new Sort(featureClassSort, featureCodeSort, populationSort);
-					
+
 					ScoreDoc[] hits = searcher.search(q, hitsPerPage , sort).scoreDocs;
 
 					List<List<String>> topHits = new ArrayList<List<String>>();
@@ -190,10 +237,7 @@ public class GeoNameResolver {
 
 		HashMap<String, List<String>> resolvedEntities = new HashMap<String, List<String>>();
 		pickBestCandidates(resolvedEntities, allCandidates, count);
-		reader.close();
-
 		return resolvedEntities;
-
 	}
 
 	/**
@@ -201,13 +245,13 @@ public class GeoNameResolver {
 	 * choosing from among a list of lists of candidate matches. Filter uses the
 	 * following features: 1) edit distance between name and the resolved name,
 	 * choose smallest one 2) content (haven't implemented)
-	 * 
+	 *
 	 * @param resolvedEntities
 	 *            final result for the input stream
 	 * @param allCandidates
 	 *            each location name may hits several documents, this is the
 	 *            collection for all hitted documents
-	 * @param count 
+	 * @param count
 	 * 			  Number of results for one locations
 	 * @throws IOException
 	 * @throws RuntimeException
@@ -218,11 +262,11 @@ public class GeoNameResolver {
 			HashMap<String, List<List<String>>> allCandidates, int count) {
 
 		for (String extractedName : allCandidates.keySet()) {
-			
+
 			List<List<String>> cur = allCandidates.get(extractedName);
 			if(cur.isEmpty())
 				continue;//continue if no results found
-			
+
 			int maxWeight = Integer.MIN_VALUE ;
 			//In case weight is equal for all return top element
 			int bestIndex = 0;
@@ -239,9 +283,9 @@ public class GeoNameResolver {
 				// get cur's ith resolved entry's name
 				String resolvedName = cur.get(i).get(0);
 				//Assign a weight as per configuration if extracted name is found in name
-				weight = resolvedName.contains(extractedName) ? WEIGHT_NAME_MATCH : 0;  
-				
-				// get all alternate names of cur's ith resolved entry's 
+				weight = resolvedName.contains(extractedName) ? WEIGHT_NAME_MATCH : 0;
+
+				// get all alternate names of cur's ith resolved entry's
 				String[] altNames = cur.get(i).get(3).split(",");
 				float altEditDist = 0;
 				for(String altName : altNames){
@@ -251,34 +295,34 @@ public class GeoNameResolver {
 				}
 				//lesser the edit distance more should be the weight
 				weight += getCalibratedWeight(altNames.length, altEditDist);
-				
+
 				//Give preference to sorted results. 0th result should have more priority
 				weight += (cur.size()-i) * WEIGHT_SORT_ORDER;
-				
+
 				cur.get(i).add(Integer.toString(weight));
-						
+
 				if (weight > maxWeight) {
 					maxWeight = weight;
 					bestIndex = i;
 				}
-				
+
 				pq.add(cur.get(i)) ;
 			}
 			if (bestIndex == -1)
 				continue;
-			
+
 			List<String> resultList = new ArrayList<>();
-			
+
 			for(int i =0 ; i< count && !pq.isEmpty() ; i++){
 				List<String> result = pq.poll();
 				//remove weight from allCandidates element before adding
 				result.remove(7);
 				//remove alternate name from allCandidates element before adding
 				result.remove(3);
-				
+
 				resultList.addAll(result);
 			}
-			
+
 			resolvedEntities.put(extractedName, resultList);
 		}
 	}
@@ -286,20 +330,20 @@ public class GeoNameResolver {
 	/**
 	 * Returns a weight for average edit distance for set of alternate name<br/><br/>
 	 * altNamesSize * WEIGHT_SIZE_ALT_NAME - (altEditDist/altNamesSize) ;<br/><br/>
-	 * altNamesSize * WEIGHT_SIZE_ALT_NAME ensure more priority for results with more alternate names.<br/> 
+	 * altNamesSize * WEIGHT_SIZE_ALT_NAME ensure more priority for results with more alternate names.<br/>
 	 * altEditDist/altNamesSize is average edit distance. <br/>
 	 * Lesser the average, higher the over all expression
 	 * @param altNamesSize - Count of altNames
 	 * @param altEditDist - sum of individual edit distances
 	 * @return
 	 */
-	public float getCalibratedWeight(int altNamesSize, float altEditDist) { 
+	public float getCalibratedWeight(int altNamesSize, float altEditDist) {
 		return altNamesSize * WEIGHT_SIZE_ALT_NAME - (altEditDist/altNamesSize) ;
 	}
 
 	/**
 	 * Build the gazetteer index line by line
-	 * 
+	 *
 	 * @param gazetteerPath
 	 *            path of the gazetteer file
 	 * @param indexerPath
@@ -342,7 +386,7 @@ public class GeoNameResolver {
 
 	/**
 	 * Index gazetteer's one line data by built-in Lucene Index functions
-	 * 
+	 *
 	 * @param indexWriter
 	 *            Lucene indexWriter to be loaded
 	 * @param line
@@ -404,10 +448,97 @@ public class GeoNameResolver {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-
 	}
 
-	public static void main(String[] args) throws IOException {
+	@Override
+	public void close() throws IOException {
+		if (indexReader != null) {
+			this.indexReader.close();
+		}
+	}
+
+	public static class SearchHandler extends AbstractHandler {
+		public static final String Q_PARAM = "q";
+		public static final String COUNT_PARAM = "count";
+
+		private final GeoNameResolver resolver;
+
+		public SearchHandler(GeoNameResolver resolver) {
+			this.resolver = resolver;
+		}
+
+		@Override
+		public void handle(String path, Request request,
+						   HttpServletRequest httpServletRequest,
+						   HttpServletResponse httpServletResponse)
+				throws IOException, ServletException {
+			LOG.log(Level.FINE, "Request :" + path);
+			Map<String, String[]> params = request.getParameterMap();
+			int count = params.containsKey(COUNT_PARAM)
+					? Integer.parseInt(request.getParameter(COUNT_PARAM))
+					: 1;
+			if (params.containsKey(Q_PARAM)){
+				List<String> locationNames = Arrays.asList(params.get(Q_PARAM));
+				HashMap<String, List<String>> result = resolver.searchGeoName(locationNames, count);
+				try (PrintStream out = new PrintStream(httpServletResponse.getOutputStream())) {
+					writeResult(result, out);
+				}
+				httpServletResponse.setStatus(HttpStatus.OK_200);
+				httpServletResponse.setContentType("application/json");
+			} else {
+				httpServletResponse.setStatus(HttpStatus.BAD_REQUEST_400);
+			}
+			request.setHandled(true);
+		}
+	}
+
+	/**
+	 * Launches embedded jetty on the specified port
+	 * @param port port number
+	 * @param geoNameResolver name resolver
+	 * @throws Exception when an error occurs
+     */
+	public static void launchService(int port, GeoNameResolver geoNameResolver) throws Exception {
+		System.out.println("Launching Service on Port : " + port);
+		Server server = new Server(port);
+		server.setHandler(new SearchHandler(geoNameResolver));
+		server.start();
+		server.join();
+	}
+
+	/**
+	 * Writes the result to given PrintStream
+	 * @param resolvedEntities map of resolved entities
+	 * @param out the print stream for writing output
+	 */
+	private static void writeResult(Map<String, List<String>> resolvedEntities, PrintStream out) {
+		out.println("[");
+		List<String> keys = (List<String>)(List<?>) Arrays.asList(resolvedEntities.keySet().toArray());
+		//TODO: use org.json.JSONArray and remove this custom formatting code
+		for (int j=0; j < keys.size(); j++) {
+			String n = keys.get(j);
+			out.println("{\"" + n + "\" : [");
+			List<String> terms = resolvedEntities.get(n);
+			for (int i = 0; i < terms.size(); i++) {
+				String res = terms.get(i);
+				if (i < terms.size() - 1) {
+					out.println("\"" + res + "\",");
+				} else {
+					out.println("\"" + res + "\"");
+				}
+			}
+
+			if (j < keys.size() -1){
+				out.println("]},");
+			}
+			else{
+				out.println("]}");
+			}
+		}
+		out.println("]");
+	}
+
+	public static void main(String[] args) throws Exception {
 		Option buildOpt = OptionBuilder.withArgName("gazetteer file").hasArg().withLongOpt("build")
 				.withDescription("The Path to the Geonames allCountries.txt")
 				.create('b');
@@ -426,20 +557,25 @@ public class GeoNameResolver {
 
 		Option helpOpt = OptionBuilder.withLongOpt("help")
 				.withDescription("Print this message.").create('h');
-		
+
 		Option resultCountOpt = OptionBuilder.withArgName("number of results").withLongOpt("count").hasArgs()
 				.withDescription("Number of best results to be returned for one location").withType(Integer.class)
 				.create('c');
 
+		Option serverOption = OptionBuilder.withArgName("Launch Server")
+				.withLongOpt("server")
+				.withDescription("Launches Geo Gazetteer Service")
+				.create("server");
+
 		String indexPath = null;
 		String gazetteerPath = null;
-		List<String> geoTerms = null;
 		Options options = new Options();
 		options.addOption(buildOpt);
 		options.addOption(searchOpt);
 		options.addOption(indexOpt);
 		options.addOption(helpOpt);
 		options.addOption(resultCountOpt);
+		options.addOption(serverOption);
 
 		// create the parser
 		CommandLineParser parser = new DefaultParser();
@@ -470,7 +606,7 @@ public class GeoNameResolver {
 			}
 
 			if (line.hasOption("search")) {
-				geoTerms = new ArrayList<String>(Arrays.asList(line
+				List<String> geoTerms = new ArrayList<String>(Arrays.asList(line
 						.getOptionValues("search")));
 				String countStr = line.getOptionValue("count", "1");
 				int count = 1;
@@ -479,29 +615,17 @@ public class GeoNameResolver {
 
 				Map<String, List<String>> resolved = resolver
 						.searchGeoName(indexPath, geoTerms, count);
-				System.out.println("[");
-				List<String> keys = (List<String>)(List<?>)Arrays.asList(resolved.keySet().toArray());
-				for (int j=0; j < keys.size(); j++) {
-					String n = keys.get(j);
-					System.out.println("{\"" + n + "\" : [");
-					List<String> terms = resolved.get(n);
-					for (int i = 0; i < terms.size(); i++) {
-						String res = terms.get(i);
-						if (i < terms.size() - 1) {
-							System.out.println("\"" + res + "\",");
-						} else {
-							System.out.println("\"" + res + "\"");
-						}
-					}
-					
-					if (j < keys.size() -1){
-						System.out.println("]},");						
-					}
-					else{
-						System.out.println("]}");
-					}
+				writeResult(resolved, System.out);
+			} else if (line.hasOption("server")){
+				if (indexPath == null) {
+					System.err.println("Index path is required");
+					System.exit(-2);
 				}
-				System.out.println("]");
+				int port = 8765;
+				launchService(port, new GeoNameResolver(indexPath));
+			} else {
+				System.err.println("Sub command not recognised");
+				System.exit(-1);
 			}
 
 		} catch (ParseException exp) {

--- a/src/main/java/edu/usc/ir/geo/gazetteer/api/SearchResource.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/api/SearchResource.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.ir.geo.gazetteer.api;
+
+import edu.usc.ir.geo.gazetteer.GeoNameResolver;
+import edu.usc.ir.geo.gazetteer.service.Launcher;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * SearchResource is a Rest Resource which offers search on geo location name.
+ *
+ */
+@Path("/search")
+public class SearchResource {
+
+    public static final String SEARCH = "s";
+    public static final String COUNT = "c";
+    private static final Logger LOG = Logger.getLogger(SearchResource.class.getName());
+
+    private final GeoNameResolver resolver;
+
+    public SearchResource(){
+
+        String indexPath = System.getProperty(Launcher.INDEX_PATH_PROP);
+        if (indexPath == null || indexPath.isEmpty()) {
+            throw new IllegalStateException("Set Index Path with system property "
+                    + Launcher.INDEX_PATH_PROP);
+        }
+        try {
+            LOG.info("Initialising searcher from index " + indexPath);
+            this.resolver = new GeoNameResolver(indexPath);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response getSearchResults(@QueryParam(SEARCH)List<String> search,
+                                     @DefaultValue("1") @QueryParam(COUNT) int count)
+            throws IOException {
+
+        if (search == null || search.isEmpty()|| count < 1){
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        //TODO: configure JSON mapping
+        HashMap<String, List<String>> result = resolver.searchGeoName(search, count);
+        try(ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream()) {
+            try (PrintStream stream = new PrintStream(arrayOutputStream)) {
+                GeoNameResolver.writeResult(result, stream);
+            }
+            return Response
+                    .status(Response.Status.OK)
+                    .entity(arrayOutputStream.toString(StandardCharsets.UTF_8.name()))
+                    .build();
+        }
+
+    }
+
+}

--- a/src/main/java/edu/usc/ir/geo/gazetteer/service/Launcher.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/service/Launcher.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.ir.geo.gazetteer.service;
+
+import edu.usc.ir.geo.gazetteer.GeoNameResolver;
+import edu.usc.ir.geo.gazetteer.api.SearchResource;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
+
+import java.io.File;
+import java.io.IOException;
+/**
+ * This is a launcher for starting Embedded tomcat.
+ */
+public class Launcher {
+
+    public static final String INDEX_PATH_PROP = "index.path";
+
+    public static void launchService(int port, String indexPath)
+            throws IOException, LifecycleException {
+
+        Tomcat server = new Tomcat();
+        Context context = server.addContext("/", new File(".").getAbsolutePath());
+        System.setProperty(INDEX_PATH_PROP, indexPath);
+
+        Wrapper servlet = context.createWrapper();
+        servlet.setName("CXFNonSpringJaxrs");
+        servlet.setServletClass(CXFNonSpringJaxrsServlet.class.getName());
+        servlet.addInitParameter("jaxrs.serviceClasses", SearchResource.class.getName());
+
+        servlet.setLoadOnStartup(1);
+        context.addChild(servlet);
+        context.addServletMapping("/api/*", "CXFNonSpringJaxrs");
+
+        System.out.println("Starting Embedded Tomcat on port : " + port );
+        server.setPort(port);
+        server.start();
+        server.getServer().await();
+    }
+
+    public static void main(String[] args) throws IOException, LifecycleException {
+        if (args.length != 2){
+            System.err.println("Usage:\n<port> <geo/index/path>");
+            return;
+        }
+        System.out.println("WARN: This is experimental. User  '" + GeoNameResolver.class.getName() + " -server'");
+        launchService(Integer.parseInt(args[0]), args[1]);
+    }
+
+}


### PR DESCRIPTION
This PR provides service mode to geo gazeteer.
The service mode is best to use when doing large number of name to GPS lookups.
(The real delay in CLI mode are from the JVM intialization and Lucene index warmup.
Service mode requires only one JVM init and also keeps the Lucene index warm with all the cache optimizations for subsequent calls!)
# Benchmark
## CLI Mode

![cli-mode](https://cloud.githubusercontent.com/assets/1865964/11318055/0190ead2-8ff8-11e5-9a56-32d5220b2562.png)
## Service mode in embedded Jetty:

EDIT : this benchmark is no longer applicable. See UPDATE 1
![service-mode](https://cloud.githubusercontent.com/assets/1865964/11318060/0fd26e40-8ff8-11e5-9e3b-9ea7e26142de.png)
## UPDATE 1: Service Mode in Embedded Tomcat and JAX-RS with Apache CXF

![cli-mode2](https://cloud.githubusercontent.com/assets/1865964/11391609/98b97cf4-9308-11e5-83e8-f21ed6901eb9.png)

<sub>On a side note, the above screenshots show Tomcat + CXF is twice slower than embedded Jetty for minimal REST services!</sub>
