### PR TITLE
Java Annotations based CLI argument parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 	<properties>
 		<tomcat.version>8.0.28</tomcat.version>
 		<cxf.version>2.2.3</cxf.version>
+		<args4j.version>2.32</args4j.version>
 	</properties>
 	<name>Geonames Gazetteer using Lucene</name>
 	<description>An implementation of a geonames.org-based Gazetteer using Apache Lucene.</description>
@@ -62,9 +63,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-cli</groupId>
-			<artifactId>commons-cli</artifactId>
-			<version>1.3</version>
+			<groupId>args4j</groupId>
+			<artifactId>args4j</artifactId>
+			<version>${args4j.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
@@ -35,14 +35,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.usc.ir.geo.gazetteer.service.Launcher;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -67,6 +59,9 @@ import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
 
 public class GeoNameResolver implements Closeable {
 	/**
@@ -100,6 +95,35 @@ public class GeoNameResolver implements Closeable {
 
 	private IndexReader indexReader;
 
+	@Option(name = "-b", aliases = {"--build"}, forbids = {"-s", "-server"},
+			usage = "The Path to the Geonames allCountries.txt")
+	private File gazetteerFile;
+
+	@Option(name = "-i", aliases = {"--index"},
+			usage = "The path to the Lucene index directory to either create or read")
+	private File indexDirectory;
+
+	@Option(name = "-s", aliases = {"--search"}, forbids = {"-b", "-server"},
+			usage = "Location names to search the Gazetteer for")
+	private List<String> geoNames;
+
+	@Option(name = "-c", aliases = {"--count"}, depends = "-s",
+			usage = "Number of best results to be returned for one location")
+	private int count = 1;
+
+	@Option(name = "-server", aliases = {"--server"},
+			usage = "Launches Geo Gazetteer Service")
+	private boolean launchServer;
+
+	@Option(name="-p", aliases = {"--port"}, depends = "-server",
+			usage = "Port number for launching service")
+	private int port = 8765;
+
+	@Option(name="-h", aliases = {"--help"},
+			usage = "Show help message")
+	private boolean showHelp;
+
+
 	public GeoNameResolver(){
 	}
 
@@ -121,6 +145,9 @@ public class GeoNameResolver implements Closeable {
 	 */
 	public HashMap<String, List<String>> searchGeoName(List<String> locationNames,
 													   int count) throws IOException {
+		if (this.indexReader == null) {
+			this.indexReader = createIndexReader(this.indexDirectory.getPath());
+		}
 		return resolveEntities(locationNames, count, this.indexReader);
 	}
 
@@ -137,13 +164,15 @@ public class GeoNameResolver implements Closeable {
 	 */
 
 	public HashMap<String, List<String>> searchGeoName(String indexerPath,
-													   List<String> locationNameEntities, int count) throws IOException {
+													   List<String> locationNameEntities,
+													   int count) throws IOException {
 
 		if (locationNameEntities.size() == 0
 				|| locationNameEntities.get(0).length() == 0)
 			return new HashMap<String, List<String>>();
 		IndexReader reader = createIndexReader(indexerPath);
-		HashMap<String, List<String>> resolvedEntities = resolveEntities(locationNameEntities, count, reader);
+		HashMap<String, List<String>> resolvedEntities =
+				resolveEntities(locationNameEntities, count, reader);
 		reader.close();
 		return resolvedEntities;
 
@@ -337,16 +366,12 @@ public class GeoNameResolver implements Closeable {
 	/**
 	 * Build the gazetteer index line by line
 	 *
-	 * @param gazetteerPath
-	 *            path of the gazetteer file
-	 * @param indexerPath
-	 *            path to the created Lucene index directory.
 	 * @throws IOException
 	 * @throws RuntimeException
 	 */
-	public void buildIndex(String gazetteerPath, String indexerPath)
+	public void buildIndex()
 			throws IOException {
-		File indexfile = new File(indexerPath);
+		File indexfile = indexDirectory;
 		indexDir = FSDirectory.open(indexfile.toPath());
 		if (!DirectoryReader.indexExists(indexDir)) {
 			IndexWriterConfig config = new IndexWriterConfig(analyzer);
@@ -354,7 +379,7 @@ public class GeoNameResolver implements Closeable {
 			Logger logger = Logger.getLogger(this.getClass().getName());
 			logger.log(Level.WARNING, "Start Building Index for Gazatteer");
 			BufferedReader filereader = new BufferedReader(
-					new InputStreamReader(new FileInputStream(gazetteerPath),
+					new InputStreamReader(new FileInputStream(gazetteerFile),
 							"UTF-8"));
 			String line;
 			int count = 0;
@@ -483,101 +508,41 @@ public class GeoNameResolver implements Closeable {
 		out.println("]");
 	}
 
+
 	public static void main(String[] args) throws Exception {
-		Option buildOpt = OptionBuilder.withArgName("gazetteer file").hasArg().withLongOpt("build")
-				.withDescription("The Path to the Geonames allCountries.txt")
-				.create('b');
-
-		Option searchOpt = OptionBuilder.withArgName("set of location names").withLongOpt("search").hasArgs()
-				.withDescription("Location names to search the Gazetteer for")
-				.create('s');
-
-		Option indexOpt = OptionBuilder
-				.withArgName("directoryPath")
-				.withLongOpt("index")
-				.hasArgs()
-				.withDescription(
-						"The path to the Lucene index directory to either create or read")
-				.create('i');
-
-		Option helpOpt = OptionBuilder.withLongOpt("help")
-				.withDescription("Print this message.").create('h');
-
-		Option resultCountOpt = OptionBuilder.withArgName("number of results").withLongOpt("count").hasArgs()
-				.withDescription("Number of best results to be returned for one location").withType(Integer.class)
-				.create('c');
-
-		Option serverOption = OptionBuilder.withArgName("Launch Server")
-				.withLongOpt("server")
-				.withDescription("Launches Geo Gazetteer Service")
-				.create("server");
-
-		String indexPath = null;
-		String gazetteerPath = null;
-		Options options = new Options();
-		options.addOption(buildOpt);
-		options.addOption(searchOpt);
-		options.addOption(indexOpt);
-		options.addOption(helpOpt);
-		options.addOption(resultCountOpt);
-		options.addOption(serverOption);
-
-		// create the parser
-		CommandLineParser parser = new DefaultParser();
 		GeoNameResolver resolver = new GeoNameResolver();
-
+		CmdLineParser parser = new CmdLineParser(resolver);
 		try {
-			// parse the command line arguments
-			CommandLine line = parser.parse(options, args);
-
-			if (line.hasOption("index")) {
-				indexPath = line.getOptionValue("index");
-			}
-
-			if (line.hasOption("build")) {
-				gazetteerPath = line.getOptionValue("build");
-			}
-
-			if (line.hasOption("help")) {
-				HelpFormatter formatter = new HelpFormatter();
-				formatter.printHelp("lucene-geo-gazetteer", options);
-				System.exit(1);
-			}
-
-			if (indexPath != null && gazetteerPath != null) {
-				LOG.info("Building Lucene index at path: [" + indexPath
-						+ "] with geoNames.org file: [" + gazetteerPath + "]");
-				resolver.buildIndex(gazetteerPath, indexPath);
-			}
-
-			if (line.hasOption("search")) {
-				List<String> geoTerms = new ArrayList<String>(Arrays.asList(line
-						.getOptionValues("search")));
-				String countStr = line.getOptionValue("count", "1");
-				int count = 1;
-				if (countStr.matches("\\d+"))
-					count = Integer.parseInt(countStr);
-
-				Map<String, List<String>> resolved = resolver
-						.searchGeoName(indexPath, geoTerms, count);
-				writeResult(resolved, System.out);
-			} else if (line.hasOption("server")){
-				if (indexPath == null) {
-					System.err.println("Index path is required");
-					System.exit(-2);
-				}
-
-				//TODO: get port from CLI args
-				int port = 8765;
-				Launcher.launchService(port, indexPath);
-			} else {
-				System.err.println("Sub command not recognised");
+			parser.parseArgument(args);
+			if (resolver.showHelp) {
+				System.out.println("lucene-geo-gazetteer \t");
+				parser.printUsage(System.out);
+				// Tika's geo parser uses this exit status to verify availability.
+				//FIXME, Not all runtimes supports negative statuses
 				System.exit(-1);
+				return;
 			}
+		} catch (CmdLineException e){
+			System.err.println(e.getMessage());
+			parser.printUsage(System.err);
+			System.exit(2);
+		}
+		if (resolver.indexDirectory != null && resolver.gazetteerFile != null) {
+			LOG.info("Building Lucene index at path: [" + resolver.indexDirectory
+					+ "] with geoNames.org file: [" + resolver.gazetteerFile + "]");
+			resolver.buildIndex();
+		}
 
-		} catch (ParseException exp) {
-			// oops, something went wrong
-			System.err.println("Parsing failed.  Reason: " + exp.getMessage());
+		if (resolver.geoNames != null && !resolver.geoNames.isEmpty()) {
+			Map<String, List<String>> resolved = resolver
+					.searchGeoName(resolver.geoNames, resolver.count);
+			writeResult(resolved, System.out);
+		} else if (resolver.launchServer){
+			Launcher.launchService(resolver.port,
+					resolver.indexDirectory.getAbsolutePath());
+		} else {
+			System.err.println("Sub command not recognised");
+			System.exit(3);
 		}
 	}
 


### PR DESCRIPTION
(With all due respect to our decade old Commons-CLI project,...) This pull request swaps Commons-CLI with [args4j](http://args4j.kohsuke.org/) parser which solves the same problem in an elegant and _java-ish_ manner. Some of the advantages of this : 
- It leverages annotations to accept arguments specification. Annotations also serve as documentation strings and [there is a tool](http://args4j.kohsuke.org/apt.html) to easily generate HTML/XML documentation.
- No need of get() and set(), it directly binds the arguments to java beans.
- Parses the arguments to desired types like (Integer, File, URL) provided target class has a constructor that takes string argument

In addition,
- changes are backward compatible: using the same CLI args specification
- the service port number is now configurable (use option -p or --port).

Usage:

```
$ lucene-geo-gazetteer -h
lucene-geo-gazetteer    
 -b (--build) FILE  : The Path to the Geonames allCountries.txt
 -c (--count) N     : Number of best results to be returned for one location
                      (default: 1)
 -h (--help)        : Show help message (default: true)
 -i (--index) FILE  : The path to the Lucene index directory to either create
                      or read (default: /home/tg/work/projects/oss/lucene-geo-ga
                      zetteer/src/main/bin/../../../geoIndex)
 -p (--port) N      : Port number for launching service (default: 8765)
 -s (--search) VAL  : Location names to search the Gazetteer for
 -server (--server) : Launches Geo Gazetteer Service (default: false)

```
