### PR TITLE
Adding enforcer plugin to enforce java7 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,28 @@
 					</descriptors>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-java</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[1.7.0,1.8)</version>
+									<message>Error:: Please use jdk7 for compilation.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
**[1.7.0,1.8)** ensures 1.7.0<=java version<1.8
