### PR TITLE
Release profile for OSS Repository Hosting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.usc.ir</groupId>
 	<artifactId>lucene-geo-gazetteer</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.3-SNAPSHOT</version>
 	<properties>
 		<tomcat.version>8.0.28</tomcat.version>
 		<cxf.version>2.2.3</cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.usc.ir</groupId>
 	<artifactId>lucene-geo-gazetteer</artifactId>
-	<version>0.3-SNAPSHOT</version>
+	<version>0.2</version>
 	<properties>
 		<tomcat.version>8.0.28</tomcat.version>
 		<cxf.version>2.2.3</cxf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,35 @@
 	</properties>
 	<name>Geonames Gazetteer using Lucene</name>
 	<description>An implementation of a geonames.org-based Gazetteer using Apache Lucene.</description>
+	<url>https://github.com/chrismattmann/lucene-geo-gazetteer</url>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<name>Thamme Gowda N.</name>
+			<organization>USC</organization>
+		</developer>
+		<developer>
+			<name>Madhav Sharan</name>
+			<organization>USC</organization>
+		</developer>
+		<developer>
+			<name>Yun Li</name>
+			<organization>USC</organization>
+		</developer>
+		<developer>
+			<name>Chris A. Mattmann</name>
+			<organization>JPL</organization>
+		</developer>
+	</developers>
+	<scm>
+		<url>https://github.com/chrismattmann/lucene-geo-gazetteer.git</url>
+		<connection>scm:git:git://github.com/chrismattmann/lucene-geo-gazetteer.git</connection>
+	</scm>
 	<build>
 		<sourceDirectory>${basedir}/src/main/java</sourceDirectory>
 		<testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
@@ -58,6 +87,98 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>release</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.3</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.9.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>2.3</version>
+						<configuration>
+							<descriptors>
+								<descriptor>src/main/assembly/assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+						<executions>
+							<execution>
+								<id>assembly-def</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
@chrismattmann - Please review.

Checkout ->
https://oss.sonatype.org/content/groups/public/edu/usc/ir/lucene-geo-gazetteer/0.2/

How to push in Maven Central?
1. $ mvn clean deploy -P release
2. Verify on -> https://oss.sonatype.org/content/groups/staging
3. $ mvn nexus-staging:release
4. Verify release on -> https://oss.sonatype.org/content/groups/public

Ref JIRA - https://issues.sonatype.org/browse/OSSRH-19541
Ref Guide - http://central.sonatype.org/pages/ossrh-guide.html

How to use l-g-g from maven central?
1. Download latest `lucene-geo-gazetteer-<ver>-jar-with-dependencies.jar` from https://oss.sonatype.org/content/groups/public/edu/usc/ir/lucene-geo-gazetteer/
2. `alias lucene-geo-gazetteer="java -cp /path/to/lucene-geo-gazetteer-<ver>-jar-with-dependencies.jar edu.usc.ir.geo.gazetteer.GeoNameResolver -i /dir/path/to/geoIndex"`
3. `lucene-geo-gazetteer -b /path/to/allCountries.txt`
4. `lucene-geo-gazetteer -s Pasadena`
