### PR TITLE
 Reverse geocoding based on distance with coordinate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data
 .project
 target
 geoIndex
+*.zip

--- a/pom.xml
+++ b/pom.xml
@@ -185,19 +185,22 @@
 			<artifactId>lucene-core</artifactId>
 			<version>5.0.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analyzers-common</artifactId>
 			<version>5.0.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-queryparser</artifactId>
 			<version>5.0.0</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-spatial</artifactId>
+			<version>5.0.0</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
@@ -236,6 +239,7 @@
 			<artifactId>tomcat-embed-jasper</artifactId>
 			<version>${tomcat.version}</version>
 		</dependency>
+		
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>

--- a/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
@@ -35,9 +35,6 @@ import java.util.PriorityQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import edu.usc.ir.geo.gazetteer.domain.Location;
-import edu.usc.ir.geo.gazetteer.service.Launcher;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -59,20 +56,40 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedNumericSortField;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.spatial.SpatialStrategy;
+import org.apache.lucene.spatial.prefix.RecursivePrefixTreeStrategy;
+import org.apache.lucene.spatial.prefix.tree.GeohashPrefixTree;
+import org.apache.lucene.spatial.prefix.tree.SpatialPrefixTree;
+import org.apache.lucene.spatial.query.SpatialArgs;
+import org.apache.lucene.spatial.query.SpatialOperation;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 
 import com.google.gson.Gson;
+import com.spatial4j.core.context.SpatialContext;
+import com.spatial4j.core.shape.Point;
+
+import edu.usc.ir.geo.gazetteer.domain.Location;
+import edu.usc.ir.geo.gazetteer.service.Launcher;
 
 public class GeoNameResolver implements Closeable {
+	private static final double REVERSE_DISTANCE_LIMIT = 0.1;
 	private static final String JSON_OPT = "json";
+	private static final String REVERSE_OPT = "r";
+	private static final String REVERSE_LONG_OPT = "enable-reverse";
+	private static final String SEARCH_REVERSE_OPT = "sr";
+	private static final String SEARCH_REVERSE_LONG_OPT = "search-reverse";
 	/**
 	 * Below constants define name of field in lucene index
 	 */
@@ -102,8 +119,14 @@ public class GeoNameResolver implements Closeable {
 	private static Directory indexDir;
 	private static int hitsPerPage = 8;
 
-	private IndexReader indexReader;
+	//sort descending on population
+	SortField populationSort = new SortedNumericSortField(FIELD_NAME_POPULATION, SortField.Type.LONG, true);
 
+	private IndexReader indexReader;
+	private SpatialContext ctx = SpatialContext.GEO;
+	private SpatialPrefixTree grid = new GeohashPrefixTree(ctx, 11);
+	private SpatialStrategy strategy = new RecursivePrefixTreeStrategy(grid, "location");
+	 
 	public GeoNameResolver(){
 	}
 
@@ -155,6 +178,27 @@ public class GeoNameResolver implements Closeable {
 
 	}
 
+	public List<Location> searchNearby(Double latitude, Double longitude, Double distance, String indexerPath, int count) throws IOException {
+
+		SpatialArgs spatialArgs = new SpatialArgs(SpatialOperation.IsWithin,
+				ctx.makeCircle(longitude,latitude, distance));
+		
+		String key = latitude+"-"+longitude;
+		Filter filter = strategy.makeFilter(spatialArgs);
+		
+		IndexSearcher searcher = new IndexSearcher(createIndexReader(indexerPath));
+		Sort sort = new Sort(populationSort);
+		TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), filter, hitsPerPage, sort);
+
+		ScoreDoc[] scoreDocs = topDocs.scoreDocs;
+		HashMap<String, List<Location>> allCandidates = new HashMap<String, List<Location>>();
+
+		getMatchingCandidates(searcher, allCandidates, key, scoreDocs);
+		List<Location> results = allCandidates.get(key);
+		
+		return results.subList(0, count > results.size() ? results.size() : count);
+	}
+
 	private IndexReader createIndexReader(String indexerPath) throws IOException {
 		File indexfile = new File(indexerPath);
 		indexDir = FSDirectory.open(indexfile.toPath());
@@ -186,44 +230,11 @@ public class GeoNameResolver implements Closeable {
 					q = new MultiFieldQueryParser(new String[] { FIELD_NAME_NAME,
 							FIELD_NAME_ALTERNATE_NAMES }, analyzer).parse(String.format("\"%s\"", name) );
 
-					//sort descending on population
-					SortField populationSort = new SortedNumericSortField(FIELD_NAME_POPULATION, SortField.Type.LONG, true);
-
 					Sort sort = new Sort(populationSort);
 					//Fetch 3 times desired values, these will be sorted on code and only desired number will be kept
 					ScoreDoc[] hits = searcher.search(q, hitsPerPage * 3 , sort).scoreDocs;
 
-					List<Location> topHits = new ArrayList<Location>();
-
-					for (int i = 0; i < hits.length; ++i) {
-						Location tmpLocObj = new Location();
-
-						int docId = hits[i].doc;
-						Document d;
-						try {
-							d = searcher.doc(docId);
-							tmpLocObj.setName(d.get(FIELD_NAME_NAME));
-							tmpLocObj.setLongitude(d.get(FIELD_NAME_LONGITUDE));
-							tmpLocObj.setLatitude(d.get(FIELD_NAME_LATITUDE));
-							//If alternate names are empty put name as actual name
-							//This covers missing data and equals weight for later computation
-							if (d.get(FIELD_NAME_ALTERNATE_NAMES).isEmpty()){
-								tmpLocObj.setAlternateNames(d.get(FIELD_NAME_NAME));
-							}else{
-								tmpLocObj.setAlternateNames(d.get(FIELD_NAME_ALTERNATE_NAMES));
-							}
-							tmpLocObj.setCountryCode(d.get(FIELD_NAME_COUNTRY_CODE));
-							tmpLocObj.setAdmin1Code(d.get(FIELD_NAME_ADMIN1_CODE));
-							tmpLocObj.setAdmin2Code(d.get(FIELD_NAME_ADMIN2_CODE));
-							tmpLocObj.setFeatureCode(d.get(FIELD_NAME_FEATURE_CODE));
-
-						} catch (IOException e) {
-							e.printStackTrace();
-						}
-						topHits.add(tmpLocObj);
-					}
-					//Picking hitsPerPage number of locations from feature code sorted list 
-					allCandidates.put(name, pickTopSortedByCode(topHits,hitsPerPage));
+					getMatchingCandidates(searcher, allCandidates, name, hits);
 				} catch (org.apache.lucene.queryparser.classic.ParseException e) {
 					e.printStackTrace();
 				}
@@ -233,6 +244,41 @@ public class GeoNameResolver implements Closeable {
 		HashMap<String, List<Location>> resolvedEntities = new HashMap<String, List<Location>>();
 		pickBestCandidates(resolvedEntities, allCandidates, count);
 		return resolvedEntities;
+	}
+
+	private void getMatchingCandidates(IndexSearcher searcher, HashMap<String, List<Location>> allCandidates,
+			String name, ScoreDoc[] hits) {
+		List<Location> topHits = new ArrayList<Location>();
+
+		for (int i = 0; i < hits.length; ++i) {
+			Location tmpLocObj = new Location();
+
+			int docId = hits[i].doc;
+			Document d;
+			try {
+				d = searcher.doc(docId);
+				tmpLocObj.setName(d.get(FIELD_NAME_NAME));
+				tmpLocObj.setLongitude(d.get(FIELD_NAME_LONGITUDE));
+				tmpLocObj.setLatitude(d.get(FIELD_NAME_LATITUDE));
+				//If alternate names are empty put name as actual name
+				//This covers missing data and equals weight for later computation
+				if (d.get(FIELD_NAME_ALTERNATE_NAMES).isEmpty()){
+					tmpLocObj.setAlternateNames(d.get(FIELD_NAME_NAME));
+				}else{
+					tmpLocObj.setAlternateNames(d.get(FIELD_NAME_ALTERNATE_NAMES));
+				}
+				tmpLocObj.setCountryCode(d.get(FIELD_NAME_COUNTRY_CODE));
+				tmpLocObj.setAdmin1Code(d.get(FIELD_NAME_ADMIN1_CODE));
+				tmpLocObj.setAdmin2Code(d.get(FIELD_NAME_ADMIN2_CODE));
+				tmpLocObj.setFeatureCode(d.get(FIELD_NAME_FEATURE_CODE));
+
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			topHits.add(tmpLocObj);
+		}
+		//Picking hitsPerPage number of locations from feature code sorted list 
+		allCandidates.put(name, pickTopSortedByCode(topHits,hitsPerPage));
 	}
 	
 	/**
@@ -356,10 +402,11 @@ public class GeoNameResolver implements Closeable {
 	 *            path of the gazetteer file
 	 * @param indexerPath
 	 *            path to the created Lucene index directory.
+	 * @param reverseGeocodingEnabled 
 	 * @throws IOException
 	 * @throws RuntimeException
 	 */
-	public void buildIndex(String gazetteerPath, String indexerPath)
+	public void buildIndex(String gazetteerPath, String indexerPath, boolean reverseGeocodingEnabled)
 			throws IOException {
 		File indexfile = new File(indexerPath);
 		indexDir = FSDirectory.open(indexfile.toPath());
@@ -379,11 +426,12 @@ public class GeoNameResolver implements Closeable {
 					if (count % 100000 == 0) {
 						logger.log(Level.INFO, "Indexed Row Count: " + count);
 					}
-					addDoc(indexWriter, line);
+					addDoc(indexWriter, line, reverseGeocodingEnabled);
 
 				} catch (RuntimeException re) {
-					logger.log(Level.WARNING, "Skipping... Error on line: {}",
+					logger.log(Level.WARNING, "Skipping... Error on line: {0}",
 							line);
+					re.printStackTrace();
 				}
 			}
 			logger.log(Level.WARNING, "Building Finished");
@@ -402,7 +450,7 @@ public class GeoNameResolver implements Closeable {
 	 * @throws IOException
 	 * @throws NumberFormatException
 	 */
-	private static void addDoc(IndexWriter indexWriter, final String line) {
+	private void addDoc(IndexWriter indexWriter, final String line, final boolean reverseGeocodingEnabled) {
 		String[] tokens = line.split("\t");
 
 		int ID = Integer.parseInt(tokens[0]);
@@ -447,7 +495,13 @@ public class GeoNameResolver implements Closeable {
 		doc.add(new TextField(FIELD_NAME_ADMIN1_CODE, admin1Code, Field.Store.YES));
 		doc.add(new TextField(FIELD_NAME_ADMIN2_CODE, admin2Code, Field.Store.YES));
 		doc.add(new NumericDocValuesField(FIELD_NAME_POPULATION, population));//sort enabled field
-
+		
+		if (reverseGeocodingEnabled) {
+			Point point = ctx.makePoint(longitude, latitude);
+			for (IndexableField f : strategy.createIndexableFields(point)) {
+				doc.add(f);
+			}
+		}
 
 		try {
 			indexWriter.addDocument(doc);
@@ -541,6 +595,16 @@ public class GeoNameResolver implements Closeable {
 				.withDescription("Formats output in well defined json structure")
 				.create(JSON_OPT);
 
+		Option reverseOption = OptionBuilder.withArgName("true / false ").hasArg()
+				.withLongOpt(REVERSE_LONG_OPT)
+				.withDescription("Add on indexing option for reverse geocoding. Defaults to false")
+				.create(REVERSE_OPT);
+
+		Option searchReverseOpt = OptionBuilder.withArgName("latitude , longitude").hasArgs()
+				.withLongOpt(SEARCH_REVERSE_LONG_OPT)
+				.withDescription("Search locations near this coordinate")
+				.create(SEARCH_REVERSE_OPT);
+
 		String indexPath = null;
 		String gazetteerPath = null;
 		Options options = new Options();
@@ -551,6 +615,8 @@ public class GeoNameResolver implements Closeable {
 		options.addOption(resultCountOpt);
 		options.addOption(serverOption);
 		options.addOption(jsonOption);
+		options.addOption(reverseOption);
+		options.addOption(searchReverseOpt);
 
 		// create the parser
 		CommandLineParser parser = new DefaultParser();
@@ -577,7 +643,18 @@ public class GeoNameResolver implements Closeable {
 			if (indexPath != null && gazetteerPath != null) {
 				LOG.info("Building Lucene index at path: [" + indexPath
 						+ "] with geoNames.org file: [" + gazetteerPath + "]");
-				resolver.buildIndex(gazetteerPath, indexPath);
+				boolean reverseEnabled = Boolean.valueOf(line.getOptionValue(REVERSE_LONG_OPT,"false"));
+				
+				resolver.buildIndex(gazetteerPath, indexPath, reverseEnabled);
+			}
+			if (line.hasOption(SEARCH_REVERSE_LONG_OPT)) {
+				String[] latLong = line.getOptionValues(SEARCH_REVERSE_LONG_OPT);
+				int count = Integer.parseInt(line.getOptionValue("count", "1"));
+				
+				List<Location> resolved = resolver
+							.searchNearby(Double.parseDouble(latLong[0]), Double.parseDouble(latLong[1]), REVERSE_DISTANCE_LIMIT, indexPath, count);
+				
+				System.out.println(new Gson().toJson(resolved));
 			}
 
 			if (line.hasOption("search")) {

--- a/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
+++ b/src/main/java/edu/usc/ir/geo/gazetteer/GeoNameResolver.java
@@ -188,7 +188,7 @@ public class GeoNameResolver implements Closeable {
 		
 		IndexSearcher searcher = new IndexSearcher(createIndexReader(indexerPath));
 		Sort sort = new Sort(populationSort);
-		TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), filter, hitsPerPage, sort);
+		TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), filter, count, sort);
 
 		ScoreDoc[] scoreDocs = topDocs.scoreDocs;
 		HashMap<String, List<Location>> allCandidates = new HashMap<String, List<Location>>();
@@ -196,7 +196,7 @@ public class GeoNameResolver implements Closeable {
 		getMatchingCandidates(searcher, allCandidates, key, scoreDocs);
 		List<Location> results = allCandidates.get(key);
 		
-		return results.subList(0, count > results.size() ? results.size() : count);
+		return results;
 	}
 
 	private IndexReader createIndexReader(String indexerPath) throws IOException {

--- a/src/test/java/edu/usc/ir/geo/gazetteer/RunReverseSearch.java
+++ b/src/test/java/edu/usc/ir/geo/gazetteer/RunReverseSearch.java
@@ -30,7 +30,7 @@ public class RunReverseSearch {
 
 		resolver.buildIndex("./cities1000.txt", indexPath, false);
 		System.out.println("Places Near Los Angeles");
-		System.out.println(resolver.searchNearby(34.022157, -118.285152, 0.1,indexPath, 10));
+		System.out.println(resolver.searchNearby(34.022157, -118.285152, 5.0,indexPath, 10));
 		
 		resolver.close();
 

--- a/src/test/java/edu/usc/ir/geo/gazetteer/RunReverseSearch.java
+++ b/src/test/java/edu/usc/ir/geo/gazetteer/RunReverseSearch.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.usc.ir.geo.gazetteer;
+
+import java.io.IOException;
+
+public class RunReverseSearch {
+
+	/**
+	 * One sample program to run reverse search
+	 */
+	public static void main(String[] args) throws IOException {
+		String indexPath = "./geoIndex";
+		GeoNameResolver resolver = new GeoNameResolver();
+
+		resolver.buildIndex("./cities1000.txt", indexPath, false);
+		System.out.println("Places Near Los Angeles");
+		System.out.println(resolver.searchNearby(34.022157, -118.285152, 0.1,indexPath, 10));
+		
+		resolver.close();
+
+	}
+
+}


### PR DESCRIPTION
#23

Two new parameters
1.  -r,--enable-reverse <true / false >           Add on indexing option for reverse geocoding. Defaults to false
2. -sr,--search-reverse <latitude , longitude>   Search locations near this coordinate

Sample commands-

```
lucene-geo-gazetteer -b /path/to/geonames/file.txt -r true -i ./geoIndex

lucene-geo-gazetteer -sr 34.022157 -118.285152
[{"name":"Los
Angeles","countryCode":"US","admin1Code":"CA","admin2Code":"037","latitu
de":34.05223,"longitude":-118.24368}]
```
